### PR TITLE
Pin cython version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.3
-cython>=0.29
+cython>=0.29,<3
 qiskit-terra>=0.21
 qiskit-ibmq-provider>=0.19.2
 psutil


### PR DESCRIPTION
Cython 3.0 seems to cause performance regression especially with openmp as follows. This PR pins cython version <3.

```python
from qiskit import QuantumCircuit
from qiskit_aer import AerSimulator
from mthree import M3Mitigation


def run(qc, backend, shots, method):
    mit = M3Mitigation(backend)
    qubits = range(qc.num_qubits)
    mit.cals_from_system(qubits)
    result = backend.run(qc, shots=shots).result()
    raw_counts = result.get_counts()
    quasi, details = mit.apply_correction(raw_counts, qubits, details=True, method=method)
    return details["time"], details["method"]


if __name__ == "__main__":
    n = 10
    shots = 10000

    qc = QuantumCircuit(n, n)
    qc.h(range(n))
    qc.measure_all(add_bits=False)

    backend = AerSimulator()

    for method in ["direct", "iterative"]:
        time, method = run(qc=qc, backend=backend, shots=shots, method=method)
        print(f"num_qubits: {n}, shots: {shots}, method: {method} -> time: {time}")
```

```
environment:
Ubuntu 22.04.3 LTS
Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz
4 cores
Python 3.10.12
gcc 11.4.0

mthree 2.6.0 (main branch, no openmp, cython 3.0.2)
  num_qubits: 11, shots: 10000, method: direct -> time: 1.2882145599869546
  num_qubits: 11, shots: 10000, method: iterative -> time: 3.038165299993125

mthree 2.6.0 (main branch, openmp, cython 3.0.2)
  num_qubits: 11, shots: 10000, method: direct -> time: 11.744204000002355
  num_qubits: 11, shots: 10000, method: iterative -> time: 35.36503065700526

mthree 2.6.0 (main branch, no openmp, cython 0.29.36)
  num_qubits: 11, shots: 10000, method: direct -> time: 0.45048408101138193
  num_qubits: 11, shots: 10000, method: iterative -> time: 0.5220816770015517

mthree 2.6.0 (main branch, openmp, cython 0.29.36)
  num_qubits: 11, shots: 10000, method: direct -> time: 0.3350270500086481
  num_qubits: 11, shots: 10000, method: iterative -> time: 0.2477201790024992 
```