### PR TITLE
remove deploy documentation to /documentation

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # This code is part of Qiskit.
@@ -31,6 +30,3 @@ pwd
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to qiskit.org/ecosystem"
 rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/ecosystem/mthree
-
-# Push to qiskit.org/documentation
-rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/partners/mthree


### PR DESCRIPTION
Follow up on https://github.com/Qiskit-Extensions/mthree/pull/151

The documentation is correctly deployed in https://qiskit.org/ecosystem/mthree/ . So, no need to upload to /documentation anymore.