### PR TITLE
Remove qiskit-ibmq-provider from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ numpy>=1.17
 scipy>=1.3
 cython>=0.29,<3
 qiskit-terra>=0.21
-qiskit-ibmq-provider>=0.19.2
 psutil
 orjson>=3.0.0


### PR DESCRIPTION
The qiskit-ibmq-provider package has been retired and is no longer maintained. It was listed in the mthree requirements, but nothing seems to actively depend on it. This commit removes the entry from the requirements list to fix this.

Fixes: #190