### PR TITLE
Pin qiskit-aer version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 qiskit>=0.28
+qiskit-aer<=0.12.0
 pytest
 pylint
 pycodestyle


### PR DESCRIPTION
The building of the documentation was failing because we were using an incompatible version of qiskit-aer. This PR pins the version to the one available in the last deployment of the docs 7 months ago.