### PR TITLE
Depend on qiskit directly

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-qiskit>=0.28
 qiskit-aer
 pytest
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.3
 cython>=0.29,<3
-qiskit-terra>=0.21
+qiskit>=0.28,<1
 psutil
 orjson>=3.0.0


### PR DESCRIPTION
### Summary

Currently, `mthree` depends on `qiskit-terra`. Starting in Qiskit 1.0.0 only the `qiskit` package will be published. This PR changes the requirement to use `qiskit` instead of `qiskit-terra` (and removes it from `requirements-dev.txt` as it seems redundant).

### Details and comments

https://github.com/Qiskit/qiskit/pull/11230