### PR TITLE
Revert/mpl/1

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -16,7 +16,7 @@ over direct LU factorization (selection also depends on free memory).
 
 .. jupyter-execute::
 
-    from qiskit.providers.fake_provider import FakeCasablanca
+    from qiskit_ibm_runtime.fake_provider import FakeCasablanca
     import mthree
 
     backend = FakeCasablanca()

--- a/docs/balanced.rst
+++ b/docs/balanced.rst
@@ -17,7 +17,7 @@ consider the balanced calibration circuits for 5 qubits:
 
 .. jupyter-execute::
 
-    from qiskit.providers.fake_provider import FakeAthens
+    from qiskit_ibm_runtime.fake_provider import FakeAthens
     import mthree
 
     mthree.circuits.balanced_cal_strings(5)

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -22,7 +22,7 @@ needed modules, and construct a circuit of interest.
 
     import numpy as np
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeCasablanca
+    from qiskit_ibm_runtime.fake_provider import FakeCasablanca
     import mthree
 
     qc = QuantumCircuit(6)
@@ -67,7 +67,7 @@ provided that we select the correct layout.
 
 .. jupyter-execute::
 
-    from qiskit.providers.fake_provider import FakeMontreal
+    from qiskit_ibm_runtime.fake_provider import FakeMontreal
 
     backend = FakeMontreal()
     mit2 = mthree.M3Mitigation(backend)

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -34,7 +34,7 @@ needed modules, and construct a circuit of interest.
     qc.cx(5,4)
     qc.cx(1,2)
     qc.measure_all()
-    qc.draw('mpl')
+    qc.draw('text')
 
 Next we calibrate an M3 mitigator instance over qubits 0 -> 6 (Step #1):
 

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -34,7 +34,7 @@ needed modules, and construct a circuit of interest.
     qc.cx(5,4)
     qc.cx(1,2)
     qc.measure_all()
-    qc.draw('text')
+    qc.draw('mpl')
 
 Next we calibrate an M3 mitigator instance over qubits 0 -> 6 (Step #1):
 

--- a/docs/cal_io.rst
+++ b/docs/cal_io.rst
@@ -9,7 +9,7 @@ Let us generate some calibration data and save it.
 
 .. jupyter-execute::
 
-    from qiskit.providers.fake_provider import FakeCasablanca
+    from qiskit_ibm_runtime.fake_provider import FakeCasablanca
     import mthree
 
     backend = FakeCasablanca()

--- a/docs/collections.rst
+++ b/docs/collections.rst
@@ -9,7 +9,7 @@ When you mitigate over multiple circuits the return object is a :class:`mthree.c
 .. jupyter-execute::
 
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeCasablanca
+    from qiskit_ibm_runtime.fake_provider import FakeCasablanca
     import mthree
 
     qc = QuantumCircuit(6)

--- a/docs/error.rst
+++ b/docs/error.rst
@@ -14,7 +14,7 @@ Let us first calibrate the mitigator and get raw results:
 .. jupyter-execute::
 
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeCasablanca
+    from qiskit_ibm_runtime.fake_provider import FakeCasablanca
     import mthree
 
     qc = QuantumCircuit(6)

--- a/docs/error.rst
+++ b/docs/error.rst
@@ -26,7 +26,7 @@ Let us first calibrate the mitigator and get raw results:
     qc.cx(5,4)
     qc.cx(1,2)
     qc.measure_all()
-    qc.draw('text')
+    qc.draw('mpl')
 
 
 .. jupyter-execute::

--- a/docs/error.rst
+++ b/docs/error.rst
@@ -26,7 +26,7 @@ Let us first calibrate the mitigator and get raw results:
     qc.cx(5,4)
     qc.cx(1,2)
     qc.measure_all()
-    qc.draw('mpl')
+    qc.draw('text')
 
 
 .. jupyter-execute::

--- a/docs/expvals.rst
+++ b/docs/expvals.rst
@@ -17,7 +17,7 @@ a noisy-simulator.
 
     import numpy as np
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeAthens
+    from qiskit_ibm_runtime.fake_provider import FakeAthens
     import mthree
 
     backend = FakeAthens()

--- a/docs/grouped.rst
+++ b/docs/grouped.rst
@@ -12,7 +12,7 @@ this consider the following simple example:
 .. jupyter-execute::
 
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeAthens
+    from qiskit_ibm_runtime.fake_provider import FakeAthens
     import mthree
 
     qc = QuantumCircuit(4)

--- a/docs/grouped.rst
+++ b/docs/grouped.rst
@@ -19,7 +19,7 @@ this consider the following simple example:
     qc.h(0)
     qc.cx(0, range(1, 4))
     qc.measure_all()
-    qc.draw('text')
+    qc.draw('mpl')
 
 Here we will generate and execute two circuits on the target system (fake system in this case),
 and, because we have transpiled, find the final measurement mapping:

--- a/docs/grouped.rst
+++ b/docs/grouped.rst
@@ -19,7 +19,7 @@ this consider the following simple example:
     qc.h(0)
     qc.cx(0, range(1, 4))
     qc.measure_all()
-    qc.draw('mpl')
+    qc.draw('text')
 
 Here we will generate and execute two circuits on the target system (fake system in this case),
 and, because we have transpiled, find the final measurement mapping:

--- a/docs/marginals.rst
+++ b/docs/marginals.rst
@@ -16,7 +16,7 @@ Consider the following circuit that we would like to evaluate:
 .. jupyter-execute::
 
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeGuadalupe
+    from qiskit_ibm_runtime.fake_provider import FakeGuadalupe
     import mthree
 
     N = 6

--- a/docs/marginals.rst
+++ b/docs/marginals.rst
@@ -28,7 +28,7 @@ Consider the following circuit that we would like to evaluate:
     for kk in range(N//2, N-1):
         qc.ch(kk, kk+1)
     qc.measure_all()
-    qc.draw('text')
+    qc.draw('mpl')
 
 
 Let us first map this onto the target system and compute the final measurement mapping:

--- a/docs/marginals.rst
+++ b/docs/marginals.rst
@@ -28,7 +28,7 @@ Consider the following circuit that we would like to evaluate:
     for kk in range(N//2, N-1):
         qc.ch(kk, kk+1)
     qc.measure_all()
-    qc.draw('mpl')
+    qc.draw('text')
 
 
 Let us first map this onto the target system and compute the final measurement mapping:

--- a/docs/probs.rst
+++ b/docs/probs.rst
@@ -15,7 +15,7 @@ done in linear time.
 .. jupyter-execute::
 
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeCasablanca
+    from qiskit_ibm_runtime.fake_provider import FakeCasablanca
     import mthree
 
     qc = QuantumCircuit(6)

--- a/docs/sampling.ipynb
+++ b/docs/sampling.ipynb
@@ -26,7 +26,7 @@
    "outputs": [],
    "source": [
     "from qiskit import *\n",
-    "from qiskit.providers.fake_provider import FakeKolkata\n",
+    "from qiskit_ibm_runtime.fake_provider import FakeKolkata\n",
     "\n",
     "import mthree\n",
     "\n",

--- a/docs/transpiled.rst
+++ b/docs/transpiled.rst
@@ -13,7 +13,7 @@ For example consider the Bernstein-Vazirani circuit
 .. jupyter-execute::
 
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeCasablanca
+    from qiskit_ibm_runtime.fake_provider import FakeCasablanca
     import mthree
 
     qc = QuantumCircuit(5, 4)

--- a/docs/transpiled.rst
+++ b/docs/transpiled.rst
@@ -25,7 +25,7 @@ For example consider the Bernstein-Vazirani circuit
     qc.h(range(4))
     qc.barrier()
     qc.measure(range(4), range(4))
-    qc.draw('text')
+    qc.draw('mpl')
 
 The target Casablanca system does not have the needed connectivity to natively
 embed the circuit and we must SWAP map it:
@@ -34,7 +34,7 @@ embed the circuit and we must SWAP map it:
 
     backend = FakeCasablanca()
     trans_qc = transpile(qc, backend, optimization_level=3, seed_transpiler=12345)
-    trans_qc.draw('text')
+    trans_qc.draw('mpl')
 
 
 We can see from the measurements at the end that what was circuit qubit 0 is now mapped to physical

--- a/docs/transpiled.rst
+++ b/docs/transpiled.rst
@@ -25,7 +25,7 @@ For example consider the Bernstein-Vazirani circuit
     qc.h(range(4))
     qc.barrier()
     qc.measure(range(4), range(4))
-    qc.draw('mpl')
+    qc.draw('text')
 
 The target Casablanca system does not have the needed connectivity to natively
 embed the circuit and we must SWAP map it:
@@ -34,7 +34,7 @@ embed the circuit and we must SWAP map it:
 
     backend = FakeCasablanca()
     trans_qc = transpile(qc, backend, optimization_level=3, seed_transpiler=12345)
-    trans_qc.draw('mpl')
+    trans_qc.draw('text')
 
 
 We can see from the measurements at the end that what was circuit qubit 0 is now mapped to physical

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -26,7 +26,7 @@ bits they correspond to.  Here we show another example of this usage.  First we 
     qc.h(0)
     qc.cx(0, range(1,7))
     qc.measure_all()
-    qc.draw('text')
+    qc.draw('mpl')
 
 and then transpile it:
 
@@ -34,7 +34,7 @@ and then transpile it:
 
     backend = FakeCasablanca()
     trans_qc = transpile(qc, backend, optimization_level=3, seed_transpiler=54321)
-    trans_qc.draw('text')
+    trans_qc.draw('mpl')
 
 Once again we see that the physical qubits used and to which classical bits they map
 to is non-trivial to find.  Yet this information is critical for successfully mitigating

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -19,7 +19,7 @@ bits they correspond to.  Here we show another example of this usage.  First we 
 .. jupyter-execute::
 
     from qiskit import *
-    from qiskit.providers.fake_provider import FakeCasablanca
+    from qiskit_ibm_runtime.fake_provider import FakeCasablanca
     import mthree
 
     qc = QuantumCircuit(7)
@@ -66,7 +66,7 @@ For example let us compare raw data verse the mitigated results in a simple case
 
 .. jupyter-execute::
 
-    from qiskit.providers.fake_provider import FakeAthens
+    from qiskit_ibm_runtime.fake_provider import FakeAthens
     backend = FakeAthens()
     qc = QuantumCircuit(4)
     qc.h(2)

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -26,7 +26,7 @@ bits they correspond to.  Here we show another example of this usage.  First we 
     qc.h(0)
     qc.cx(0, range(1,7))
     qc.measure_all()
-    qc.draw('mpl')
+    qc.draw('text')
 
 and then transpile it:
 
@@ -34,7 +34,7 @@ and then transpile it:
 
     backend = FakeCasablanca()
     trans_qc = transpile(qc, backend, optimization_level=3, seed_transpiler=54321)
-    trans_qc.draw('mpl')
+    trans_qc.draw('text')
 
 Once again we see that the physical qubits used and to which classical bits they map
 to is non-trivial to find.  Yet this information is critical for successfully mitigating

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -24,7 +24,6 @@ import numpy as np
 import scipy.linalg as la
 import scipy.sparse.linalg as spla
 import orjson
-from qiskit import execute
 from qiskit.providers import Backend, BackendV2, BackendV1
 
 from mthree.circuits import (
@@ -424,24 +423,12 @@ class M3Mitigation:
             for kk in range(num_jobs - 1)
         ] + [trans_qcs[(num_jobs - 1) * circ_slice:]]
         # Do job submission here
-        # This Backend check is here for Qiskit direct access.  Should be removed later.
         jobs = []
-        if not isinstance(self.system, Backend):
-            for circs in circs_list:
-                _job = execute(
-                    circs,
-                    self.system,
-                    optimization_level=0,
-                    shots=shots,
-                    rep_delay=self.rep_delay,
-                )
-                jobs.append(_job)
-        else:
-            for circs in circs_list:
-                _job = self.system.run(circs, shots=shots, rep_delay=self.rep_delay)
-                jobs.append(_job)
+        for circs in circs_list:
+            _job = self.system.run(circs, shots=shots, rep_delay=self.rep_delay)
+            jobs.append(_job)
 
-        # Execute job and cal building in new theread.
+        # Execute job and cal building in new thread.
         self._job_error = None
         if async_cal:
             thread = threading.Thread(

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -24,7 +24,7 @@ import numpy as np
 import scipy.linalg as la
 import scipy.sparse.linalg as spla
 import orjson
-from qiskit.providers import Backend, BackendV2, BackendV1
+from qiskit.providers import BackendV2, BackendV1
 
 from mthree.circuits import (
     _tensor_meas_states,

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -782,7 +782,7 @@ class M3Mitigation:
         out, error = spla.gmres(
             L,
             vec,
-            tol=tol,
+            rtol=tol,
             atol=tol,
             maxiter=max_iter,
             M=P,

--- a/mthree/norms.py
+++ b/mthree/norms.py
@@ -134,13 +134,13 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
     v = (1.0/dims)*np.ones(dims, dtype=float)
 
     # Initial solve
-    v, error = spla.gmres(L, v, tol=tol, atol=tol, maxiter=max_iter,
+    v, error = spla.gmres(L, v, rtol=tol, atol=tol, maxiter=max_iter,
                           M=P)
     if error:
         raise M3Error('Iterative solver error {}'.format(error))
     gamma = la.norm(v, 1)
     eta = np.sign(v)
-    x, error = spla.gmres(LT, eta, tol=tol, atol=tol, maxiter=max_iter,
+    x, error = spla.gmres(LT, eta, rtol=tol, atol=tol, maxiter=max_iter,
                           M=P)
     if error:
         raise M3Error('Iterative solver error {}'.format(error))
@@ -151,7 +151,7 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
         idx = np.where(np.abs(x) == x_nrm)[0][0]
         v = np.zeros(dims, dtype=float)
         v[idx] = 1
-        v, error = spla.gmres(L, v, tol=tol, atol=tol, maxiter=max_iter,
+        v, error = spla.gmres(L, v, rtol=tol, atol=tol, maxiter=max_iter,
                               M=P)
         if error:
             raise M3Error('Iterative solver error {}'.format(error))
@@ -162,7 +162,7 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
             break
 
         eta = np.sign(v)
-        x, error = spla.gmres(LT, eta, tol=tol, atol=tol, maxiter=max_iter,
+        x, error = spla.gmres(LT, eta, rtol=tol, atol=tol, maxiter=max_iter,
                               M=P)
         if error:
             raise M3Error('Iterative solver error {}'.format(error))
@@ -174,7 +174,7 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
     x = np.arange(1, dims+1)
     x = (-1)**(x+1)*(1+(x-1)/(dims-1))
 
-    x, error = spla.gmres(L, x, tol=tol, atol=tol, maxiter=max_iter,
+    x, error = spla.gmres(L, x, rtol=tol, atol=tol, maxiter=max_iter,
                           M=P)
     if error:
         raise M3Error('Iterative solver error {}'.format(error))

--- a/mthree/test/test_collections.py
+++ b/mthree/test/test_collections.py
@@ -13,8 +13,8 @@
 
 """Test collection classes"""
 import numpy as np
-from qiskit import QuantumCircuit, execute
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit import QuantumCircuit
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
 
@@ -30,7 +30,7 @@ def test_mit_overhead():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute([qc]*10, backend).result().get_counts()
+    raw_counts = backend.run([qc]*10).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(5),
@@ -52,7 +52,7 @@ def test_shots():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute([qc]*10, backend, shots=4321).result().get_counts()
+    raw_counts = backend.run([qc]*10, shots=4321).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(5),

--- a/mthree/test/test_default_shots.py
+++ b/mthree/test/test_default_shots.py
@@ -12,7 +12,7 @@
 # pylint: disable=no-name-in-module
 
 """Test matrix elements"""
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
 LOW_SHOTS = 543

--- a/mthree/test/test_details.py
+++ b/mthree/test/test_details.py
@@ -13,7 +13,7 @@
 
 """Test details handling"""
 from qiskit import QuantumCircuit, transpile
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 
 import mthree
 

--- a/mthree/test/test_dynamic.py
+++ b/mthree/test/test_dynamic.py
@@ -13,10 +13,10 @@
 
 """Test matrix elements"""
 from qiskit import QuantumCircuit, transpile
-from qiskit_ibm_runtime.fake_provider import FakeKolkata
 # Transpiler passes for optimizing dynamic circuits
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes.optimization import ResetAfterMeasureSimplification
+from qiskit_ibm_runtime.fake_provider import FakeKolkata
 
 import mthree
 

--- a/mthree/test/test_dynamic.py
+++ b/mthree/test/test_dynamic.py
@@ -13,7 +13,7 @@
 
 """Test matrix elements"""
 from qiskit import QuantumCircuit, transpile
-from qiskit.providers.fake_provider import FakeKolkata
+from qiskit_ibm_runtime.fake_provider import FakeKolkata
 # Transpiler passes for optimizing dynamic circuits
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes.optimization import ResetAfterMeasureSimplification

--- a/mthree/test/test_extra_cals.py
+++ b/mthree/test/test_extra_cals.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 import orjson
-from qiskit import QuantumCircuit, execute
+from qiskit import QuantumCircuit
 from qiskit_ibm_runtime.fake_provider import FakeAthens
 
 import mthree
@@ -33,7 +33,7 @@ def test_missing_qubit_cal():
     qc.measure_all()
 
     backend = FakeAthens()
-    raw_counts = execute(qc, backend, shots=2048).result().get_counts()
+    raw_counts = backend.run(qc, shots=2048).result().get_counts()
 
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(range(4))
@@ -57,7 +57,7 @@ def test_missing_all_cals():
     qc.measure_all()
 
     backend = FakeAthens()
-    raw_counts = execute(qc, backend, shots=2048).result().get_counts()
+    raw_counts = backend.run(qc, shots=2048).result().get_counts()
 
     mit = mthree.M3Mitigation(backend)
     _ = mit.apply_correction(raw_counts, range(5))

--- a/mthree/test/test_extra_cals.py
+++ b/mthree/test/test_extra_cals.py
@@ -16,7 +16,7 @@
 import numpy as np
 import orjson
 from qiskit import QuantumCircuit, execute
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 
 import mthree
 

--- a/mthree/test/test_file_io.py
+++ b/mthree/test/test_file_io.py
@@ -14,7 +14,7 @@
 """Test cals file IO"""
 import os
 import numpy as np
-from qiskit import QuantumCircuit, execute
+from qiskit import QuantumCircuit
 from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
@@ -31,7 +31,7 @@ def test_load_cals_from_file():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(cals_file='cals.json')
 
@@ -65,7 +65,7 @@ def test_load_cals_from_file2():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(shots=12345)
     mit.cals_to_file('cals.json')

--- a/mthree/test/test_file_io.py
+++ b/mthree/test/test_file_io.py
@@ -15,7 +15,7 @@
 import os
 import numpy as np
 from qiskit import QuantumCircuit, execute
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
 

--- a/mthree/test/test_grouping.py
+++ b/mthree/test/test_grouping.py
@@ -14,7 +14,7 @@
 """Test opertor groupings"""
 import numpy as np
 from qiskit import QuantumCircuit, transpile
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
 

--- a/mthree/test/test_hamming.py
+++ b/mthree/test/test_hamming.py
@@ -13,7 +13,7 @@
 """Test Hamming distance truncation"""
 import numpy as np
 
-from qiskit.providers.fake_provider import FakeKolkata
+from qiskit_ibm_runtime.fake_provider import FakeKolkata
 import mthree
 
 

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -12,7 +12,7 @@
 
 """Test inoperable qubits"""
 import pytest
-from qiskit.providers.fake_provider import FakeKolkata
+from qiskit_ibm_runtime.fake_provider import FakeKolkata
 import mthree
 
 

--- a/mthree/test/test_list_inputs.py
+++ b/mthree/test/test_list_inputs.py
@@ -12,8 +12,8 @@
 # pylint: disable=no-name-in-module
 
 """Test list inputs"""
-from qiskit import QuantumCircuit, execute
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit import QuantumCircuit
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
 
@@ -29,7 +29,7 @@ def test_athens_sim():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction([raw_counts]*10, qubits=range(5))

--- a/mthree/test/test_matvec.py
+++ b/mthree/test/test_matvec.py
@@ -13,8 +13,8 @@
 """Test matrix elements"""
 import numpy as np
 import scipy.sparse.linalg as spla
-from qiskit import QuantumCircuit, execute
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit import QuantumCircuit
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 from mthree.matvec import M3MatVec
 
@@ -31,7 +31,7 @@ def test_matvec():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(range(5))
 

--- a/mthree/test/test_meas_mapping.py
+++ b/mthree/test/test_meas_mapping.py
@@ -12,7 +12,7 @@
 
 """Test QuantumCircuit final measurement mapping"""
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, transpile
-from qiskit.providers.fake_provider import FakeCasablanca
+from qiskit_ibm_runtime.fake_provider import FakeCasablanca
 from mthree.utils import final_measurement_mapping
 
 

--- a/mthree/test/test_methods.py
+++ b/mthree/test/test_methods.py
@@ -14,8 +14,8 @@
 """Test is various methods agree"""
 
 import numpy as np
-from qiskit import QuantumCircuit, execute
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit import QuantumCircuit
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
 
@@ -30,7 +30,7 @@ def test_methods_equality():
     qc.measure_all()
 
     backend = FakeAthens()
-    raw_counts = execute(qc, backend, shots=2048).result().get_counts()
+    raw_counts = backend.run(qc, shots=2048).result().get_counts()
 
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
@@ -54,7 +54,7 @@ def test_set_iterative():
     qc.measure_all()
 
     backend = FakeAthens()
-    raw_counts = execute(qc, backend, shots=4096).result().get_counts()
+    raw_counts = backend.run(qc, shots=4096).result().get_counts()
 
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(shots=4096)

--- a/mthree/test/test_multi_job.py
+++ b/mthree/test/test_multi_job.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """Test multiple job submission"""
-from qiskit.providers.fake_provider import FakeKolkata
+from qiskit_ibm_runtime.fake_provider import FakeKolkata
 import mthree
 
 

--- a/mthree/test/test_odd_cases.py
+++ b/mthree/test/test_odd_cases.py
@@ -12,7 +12,8 @@
 # pylint: disable=no-name-in-module
 
 """Test utils functions"""
-from qiskit import Aer, QuantumCircuit, transpile
+from qiskit_aer import Aer
+from qiskit import QuantumCircuit, transpile
 import mthree
 
 

--- a/mthree/test/test_quasi_attr.py
+++ b/mthree/test/test_quasi_attr.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 # pylint: disable=no-name-in-module
 """Test matrix elements"""
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, transpile
 from qiskit_ibm_runtime.fake_provider import FakeMontreal
 import mthree
 
@@ -24,10 +24,10 @@ def test_quasi_attr_set():
     qc = QuantumCircuit(N)
     qc.x(range(0, N))
     qc.h(range(0, N))
-    for kk in range(N//2, 0, -1):
-        qc.ch(kk, kk-1)
-    for kk in range(N//2, N-1):
-        qc.ch(kk, kk+1)
+    for kk in range(N // 2, 0, -1):
+        qc.ch(kk, kk - 1)
+    for kk in range(N // 2, N - 1):
+        qc.ch(kk, kk + 1)
     qc.measure_all()
 
     qubits = [1, 4, 7, 10, 12, 13]
@@ -35,17 +35,24 @@ def test_quasi_attr_set():
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(qubits)
 
-    raw_counts = backend.run(qc, shots=1024,
-                             initial_layout=qubits).result().get_counts()
-    quasi1 = mit.apply_correction(raw_counts, qubits,
-                                  return_mitigation_overhead=True, method='direct')
-    quasi2 = mit.apply_correction(raw_counts, qubits,
-                                  return_mitigation_overhead=True, method='iterative')
+    raw_counts = (
+        backend.run(transpile(qc, backend, initial_layout=qubits), shots=1024)
+        .result()
+        .get_counts()
+    )
+    quasi1 = mit.apply_correction(
+        raw_counts, qubits, return_mitigation_overhead=True, method="direct"
+    )
+    quasi2 = mit.apply_correction(
+        raw_counts, qubits, return_mitigation_overhead=True, method="iterative"
+    )
 
-    quasi3 = mit.apply_correction(raw_counts, qubits,
-                                  return_mitigation_overhead=False, method='direct')
-    quasi4 = mit.apply_correction(raw_counts, qubits,
-                                  return_mitigation_overhead=False, method='iterative')
+    quasi3 = mit.apply_correction(
+        raw_counts, qubits, return_mitigation_overhead=False, method="direct"
+    )
+    quasi4 = mit.apply_correction(
+        raw_counts, qubits, return_mitigation_overhead=False, method="iterative"
+    )
 
     shots = 1024
     assert quasi1.shots == shots

--- a/mthree/test/test_quasi_attr.py
+++ b/mthree/test/test_quasi_attr.py
@@ -11,8 +11,8 @@
 # that they have been altered from the originals.
 # pylint: disable=no-name-in-module
 """Test matrix elements"""
-from qiskit import QuantumCircuit, execute
-from qiskit.providers.fake_provider import FakeMontreal
+from qiskit import QuantumCircuit
+from qiskit_ibm_runtime.fake_provider import FakeMontreal
 import mthree
 
 
@@ -35,8 +35,8 @@ def test_quasi_attr_set():
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(qubits)
 
-    raw_counts = execute(qc, backend, shots=1024,
-                         initial_layout=qubits).result().get_counts()
+    raw_counts = backend.run(qc, shots=1024,
+                             initial_layout=qubits).result().get_counts()
     quasi1 = mit.apply_correction(raw_counts, qubits,
                                   return_mitigation_overhead=True, method='direct')
     quasi2 = mit.apply_correction(raw_counts, qubits,

--- a/mthree/test/test_qubits_from_mapping.py
+++ b/mthree/test/test_qubits_from_mapping.py
@@ -12,7 +12,7 @@
 
 """Test QuantumCircuit final measurement mapping"""
 from qiskit import QuantumCircuit, transpile
-from qiskit.providers.fake_provider import FakeCasablanca
+from qiskit_ibm_runtime.fake_provider import FakeCasablanca
 import mthree
 from mthree.utils import final_measurement_mapping
 

--- a/mthree/test/test_sim.py
+++ b/mthree/test/test_sim.py
@@ -12,8 +12,8 @@
 # pylint: disable=no-name-in-module
 
 """Test matrix elements"""
-from qiskit import QuantumCircuit, execute
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit import QuantumCircuit
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
 
@@ -29,7 +29,7 @@ def test_athens_sim():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(5))
@@ -49,7 +49,7 @@ def test_athens_sim_set_shots():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(range(5), 7000)
     mit_counts = mit.apply_correction(raw_counts, qubits=range(5))

--- a/mthree/test/test_threading.py
+++ b/mthree/test/test_threading.py
@@ -13,7 +13,7 @@
 """Test QuantumCircuit final measurement mapping"""
 import pytest
 from qiskit import QuantumCircuit, transpile
-from qiskit.providers.fake_provider import FakeCasablanca
+from qiskit_ibm_runtime.fake_provider import FakeCasablanca
 import mthree
 from mthree.exceptions import M3Error
 from mthree.utils import final_measurement_mapping

--- a/mthree/test/test_utils.py
+++ b/mthree/test/test_utils.py
@@ -13,7 +13,7 @@
 
 """Test utils functions"""
 import numpy as np
-from qiskit import QuantumCircuit, execute
+from qiskit import QuantumCircuit
 from qiskit.quantum_info import Statevector
 from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
@@ -29,7 +29,7 @@ def test_gen_dist0():
     qc.cx(1, 0)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(4),
@@ -52,7 +52,7 @@ def test_gen_multi_dist0():
     qc.cx(1, 0)
     qc.measure_all()
 
-    raw_counts = execute([qc]*5, backend).result().get_counts()
+    raw_counts = backend.run([qc]*5).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(4),
@@ -77,7 +77,7 @@ def test_gen_full_dist():
     qc.cx(1, 0)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(4),
@@ -101,7 +101,7 @@ def test_gen_multi_full_dist():
     qc.cx(1, 0)
     qc.measure_all()
 
-    raw_counts = execute([qc]*5, backend).result().get_counts()
+    raw_counts = backend.run([qc]*5).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(4),

--- a/mthree/test/test_utils.py
+++ b/mthree/test/test_utils.py
@@ -15,7 +15,7 @@
 import numpy as np
 from qiskit import QuantumCircuit, execute
 from qiskit.quantum_info import Statevector
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit_ibm_runtime.fake_provider import FakeAthens
 import mthree
 
 

--- a/mthree/test/test_v2_backends.py
+++ b/mthree/test/test_v2_backends.py
@@ -12,7 +12,7 @@
 # pylint: disable=no-name-in-module
 
 """Test matrix elements"""
-from qiskit.providers.fake_provider import FakeAthensV2
+from qiskit_ibm_runtime.fake_provider import FakeAthensV2
 import mthree
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.3
-cython>=0.29,<3
-qiskit>=0.28,<1
+cython>=3.0.5
+qiskit==1.0.0rc1
 psutil
 orjson>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ numpy>=1.17
 scipy>=1.3
 cython>=3.0.5
 qiskit==1.0.0rc1
+qiskit_ibm_runtime>=0.18
 psutil
 orjson>=3.0.0

--- a/tutorials/01_M3_ex1.ipynb
+++ b/tutorials/01_M3_ex1.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import numpy as np\n",
     "from qiskit import *\n",
-    "from qiskit.providers.fake_provider import FakeGuadalupe\n",
+    "from qiskit_ibm_runtime.fake_provider import FakeGuadalupe\n",
     "import mthree\n",
     "import matplotlib.pyplot as plt\n",
     "plt.style.use('quantum-light')"

--- a/tutorials/02_correcting_probs.ipynb
+++ b/tutorials/02_correcting_probs.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "import numpy as np\n",
     "from qiskit import *\n",
-    "from qiskit.providers.fake_provider import FakeMelbourne\n",
+    "from qiskit_ibm_runtime.fake_provider import FakeMelbourne\n",
     "from qiskit.visualization import plot_histogram\n",
     "import mthree"
    ]

--- a/tutorials/03_qv_example.ipynb
+++ b/tutorials/03_qv_example.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit.providers.fake_provider import FakeBurlington\n",
+    "from qiskit_ibm_runtime.fake_provider import FakeBurlington\n",
     "noisy_sim = FakeBurlington()"
    ]
   },

--- a/tutorials/04_dynamic_bv.ipynb
+++ b/tutorials/04_dynamic_bv.ipynb
@@ -28,7 +28,7 @@
     "import numpy as np\n",
     "\n",
     "from qiskit import *\n",
-    "from qiskit.providers.fake_provider import FakeKolkata, FakeKolkataV2\n",
+    "from qiskit_ibm_runtime.fake_provider import FakeKolkata, FakeKolkataV2\n",
     "\n",
     "import mthree\n",
     "\n",

--- a/tutorials/10_basic_vqe.ipynb
+++ b/tutorials/10_basic_vqe.ipynb
@@ -19,7 +19,7 @@
     "import scipy.optimize as opt\n",
     "from qiskit import *\n",
     "from qiskit.circuit.library import TwoLocal\n",
-    "from qiskit.providers.fake_provider import FakeAthens\n",
+    "from qiskit_ibm_runtime.fake_provider import FakeAthens\n",
     "import mthree"
    ]
   },


### PR DESCRIPTION
Qiskit 1.0.0rc1 has a broken MPL circuit drawer https://github.com/Qiskit/qiskit/pull/11750

As a consequence, https://github.com/Qiskit-Extensions/mthree/pull/196 switch the drawing in the docs to `text`. This issue set it back once https://github.com/Qiskit/qiskit/pull/11750 gets released. This PR is on top of https://github.com/Qiskit-Extensions/mthree/pull/196