### PR TITLE
Add support for python 3.12 and fix build system

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -12,13 +12,14 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-20.04, macos-11]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_SKIP: "cp36-* pp* *musl*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp310-manylinux*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "cython>=0.29", "oldest-supported-numpy"]
-build-backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta:__legacy__"

--- a/setup.py
+++ b/setup.py
@@ -205,6 +205,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
     ],
     cmdclass={'lint': PylintCommand,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.15
-envlist = py36, py37, py38, py39, lint, docs
+envlist = py310, py311, py312, py37, py38, py39, lint, docs
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
This commit makes two changes, the first is that it updates the package metadata and ci configuration to add support for Python 3.12. On the next release of mthree this will include a package for 3.12 users and that we test 3.12 compatibility on PRs in CI.

Related to this a small fix was needed in the build system configuration. The setuptools build-backend used for building mthree with newer versions of setuptools was incompatible with the required execution of the entire setup.py file (to generate the version.py file). To fix this the build-backend is changed to use the legacy setuptools backend which will work with the current setup for the packaging. Longer term we should investigate updated the build configuration to avoid needing to run the setup.py fully as part of the package build.

Fixes #191