### PR TITLE
Turn off exception check

### DIFF
--- a/mthree/compute.pxd
+++ b/mthree/compute.pxd
@@ -14,20 +14,20 @@ cdef unsigned int within_distance(unsigned int row,
                                   unsigned int col,
                                   const unsigned char * bitstrings,
                                   unsigned int num_bits,
-                                  unsigned int distance) nogil
+                                  unsigned int distance) noexcept nogil
 
 cdef double compute_element(unsigned int row,
                             unsigned int col,
                             const unsigned char * bitstrings,
                             const double * cals,
-                            unsigned int num_bits) nogil
+                            unsigned int num_bits) noexcept nogil
 
 cdef void compute_col_norms(double * col_norms,
                             const unsigned char * bitstrings,
                             const double * cals,
                             unsigned int num_bits,
                             unsigned int num_elems,
-                            unsigned int distance) nogil
+                            unsigned int distance) noexcept nogil
 
 cdef unsigned int hamming_terms(unsigned int num_bits,
-                                unsigned int distance) nogil
+                                unsigned int distance) noexcept nogil

--- a/mthree/compute.pyx
+++ b/mthree/compute.pyx
@@ -18,7 +18,7 @@ cdef inline unsigned int within_distance(unsigned int row,
                                          unsigned int col,
                                          const unsigned char * bitstrings,
                                          unsigned int num_bits,
-                                         unsigned int distance) nogil:
+                                         unsigned int distance) noexcept nogil:
     """Computes the Hamming distance between two bitstrings.
 
     Parameters:
@@ -47,7 +47,7 @@ cdef inline double compute_element(unsigned int row,
                                    unsigned int col,
                                    const unsigned char * bitstrings,
                                    const double * cals,
-                                   unsigned int num_bits) nogil:
+                                   unsigned int num_bits) noexcept nogil:
     """Computes the matrix element specified by the input
     bit strings from the supplied tensored cals data.
 
@@ -78,7 +78,7 @@ cdef void compute_col_norms(double * col_norms,
                             const double * cals,
                             unsigned int num_bits,
                             unsigned int num_elems,
-                            unsigned int distance) nogil:
+                            unsigned int distance) noexcept nogil:
     """Compute the matrix column norms for each bitstring.
 
     Parameters:
@@ -113,7 +113,7 @@ cdef double _inner_col_norm_loop(unsigned int col,
                                  unsigned int num_bits,
                                  unsigned int num_elems,
                                  unsigned int distance,
-                                 unsigned int MAX_DIST) nogil:
+                                 unsigned int MAX_DIST) noexcept nogil:
     """An inner-loop function for computing col_norms in parallel.
 
     This is needed to get around an issue with how Cython tries to do
@@ -143,7 +143,7 @@ cdef double _inner_col_norm_loop(unsigned int col,
 
 
 @cython.cdivision(True)
-cdef unsigned int binomial_coeff(unsigned int n, unsigned int k) nogil:
+cdef unsigned int binomial_coeff(unsigned int n, unsigned int k) noexcept nogil:
     """Computes the binomial coefficient n choose k
     
     Parameters:
@@ -167,7 +167,7 @@ cdef unsigned int binomial_coeff(unsigned int n, unsigned int k) nogil:
 
 
 @cython.boundscheck(False)
-cdef unsigned int hamming_terms(unsigned int num_bits, unsigned int distance) nogil:
+cdef unsigned int hamming_terms(unsigned int num_bits, unsigned int distance) noexcept nogil:
     """Compute the total number of terms within a given Hamming distance
     
     Parameters:

--- a/mthree/matrix.pyx
+++ b/mthree/matrix.pyx
@@ -29,7 +29,7 @@ cdef double matrix_element(unsigned int row,
                            const double * cals,
                            unsigned int num_bits,
                            unsigned int distance,
-                           unsigned int MAX_DIST) nogil:
+                           unsigned int MAX_DIST) noexcept nogil:
     
     cdef size_t kk
     cdef double out = 0
@@ -82,7 +82,7 @@ cdef void omp_element_compute(size_t jj, const unsigned char * bitstrings,
                               unsigned int distance,
                               double * W_ptr,
                               double * col_norms_ptr,
-                              unsigned int MAX_DIST) nogil:
+                              unsigned int MAX_DIST) noexcept nogil:
     """Computes the matrix elements for a single column
     """
     cdef double _temp, col_norm = 0
@@ -168,7 +168,7 @@ cdef void omp_sdd_compute(size_t row,
                           unsigned int num_bits,
                           unsigned int num_elems,
                           unsigned int distance,
-                          unsigned int MAX_DIST) nogil:
+                          unsigned int MAX_DIST) noexcept nogil:
 
     cdef size_t col
     cdef double diag_elem, mat_elem, row_sum = 0

--- a/mthree/matvec.pyx
+++ b/mthree/matvec.pyx
@@ -128,7 +128,7 @@ cdef void omp_matvec(size_t row,
                      unsigned int num_elems,
                      unsigned int num_bits,
                      unsigned int distance,
-                     bool MAX_DIST) nogil:
+                     bool MAX_DIST) noexcept nogil:
     cdef double temp_elem, row_sum = 0
     cdef size_t col
     for col in range(num_elems):
@@ -151,7 +151,7 @@ cdef void omp_rmatvec(size_t col,
                       unsigned int num_elems,
                       unsigned int num_bits,
                       unsigned int distance,
-                      bool MAX_DIST) nogil:
+                      bool MAX_DIST) noexcept nogil:
     cdef double temp_elem, row_sum = 0
     cdef size_t row
     for row in range(num_elems):


### PR DESCRIPTION
Fixes #188
Fixes #197

```python
from qiskit import QuantumCircuit
from qiskit_aer import AerSimulator
from mthree import M3Mitigation


def run(qc, backend, shots, method):
    mit = M3Mitigation(backend)
    qubits = range(qc.num_qubits)
    mit.cals_from_system(qubits)
    result = backend.run(qc, shots=shots).result()
    raw_counts = result.get_counts()
    quasi, details = mit.apply_correction(raw_counts, qubits, details=True, method=method)
    return details["time"], details["method"]


if __name__ == "__main__":
    n = 20
    shots = 10000

    qc = QuantumCircuit(n, n)
    qc.h(range(n))
    qc.measure_all(add_bits=False)

    backend = AerSimulator()

    time, method = run(qc=qc, backend=backend, shots=shots, method="auto")
    print(f"num_qubits: {n}, shots: {shots} -> time: {time}")
```

main
```
num_qubits: 20, shots: 10000 -> time: 12.706861458020285
```

this PR
```
num_qubits: 20, shots: 10000 -> time: 4.631123083003331
```