### PR TITLE
Fix release ci config issues, drop 3.7 support, and prepare 2.6.2 release

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-20.04, macos-11]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_SKIP: "cp36-* pp* *musl*"
+          CIBW_SKIP: "cp36-* cp37-* pp* *musl*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp310-manylinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
@@ -46,6 +46,7 @@ jobs:
         run: twine upload ./wheelhouse/*whl
   sdist-build:
     name: Build and Publish Release Artifacts
+    needs: [build_wheels]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from Cython.Build import cythonize
 
 MAJOR = 2
 MINOR = 6
-MICRO = 1
+MICRO = 2
 
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
@@ -184,7 +184,7 @@ class StyleCommand(setuptools.Command):
 setuptools.setup(
     name='mthree',
     version=VERSION,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     packages=PACKAGES,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
@@ -200,7 +200,6 @@ setuptools.setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.15
-envlist = py310, py311, py312, py37, py38, py39, lint, docs
+envlist = py310, py311, py312, py38, py39, lint, docs
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
This commit fixes a release ci job configuration issue stemming from the fact that the release ci jobs are setup to parallelize the sdist and wheel publishing. The issue with this is the sdist, being just a tarball, is significantly faster to publish and always goes first. But the wheel builds which actually compile the cython code and run tests are slower and much more fragile. We've had two releases in quick succession where small oversights in the packaging configuration caused the wheel jobs to fail, but by the time we hit the failure the sdist had already been published to pypi which makes it hard to rollback. This commit updates the ci configuration to fix this and only upload the sdist after the wheels are there.

Then to prepare for the second patch release on 2.6.x this commit drops support for python 3.7 and updates the ci jobs and package metadata to indicate 3.7 is no longer supported and no longer build or test it.