### PR TITLE
Drop py3.8 due to SciPy issues

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-20.04, macos-11]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_SKIP: "cp36-* cp37-* pp* *musl*"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* pp* *musl*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp310-manylinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.17
-scipy>=1.3
+scipy>=1.11
 cython>=3.0.5
 qiskit>=0.44
 qiskit_ibm_runtime>=0.18

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from Cython.Build import cythonize
 
 MAJOR = 2
 MINOR = 6
-MICRO = 2
+MICRO = 3
 
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
@@ -200,7 +200,6 @@ setuptools.setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
The SciPy interface changed from 1.10 to 1.11+ requiring updating to the latter or above.  However, this requires dropping Py38 support.  This is EOL in Oct ' 24, so not the end of the world I guess.