### PR TITLE
Fix 'gmres' calls on old Scipy versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-latest, windows-latest, macos-11]
 
     steps:
       - uses: actions/checkout@v2
@@ -30,6 +30,7 @@ jobs:
           CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test
           CIBW_TEST_COMMAND_MACOS:  pytest -p no:warnings /tmp/mthree_test
           CIBW_ENVIRONMENT_LINUX: MTHREE_OPENMP=1
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.15
           CIBW_BEFORE_TEST_LINUX: rm -rf /mthree_test && cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
           CIBW_BEFORE_TEST_WINDOWS: rm -rf C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test && cp -r {project}/mthree/test C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test && rm -f C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test\test_converters.py && rm -f C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test\test_columns.py && pip install --prefer-binary orjson
           CIBW_BEFORE_TEST_MACOS: rm -rf /tmp/mthree_test && cp -r {project}/mthree/test /tmp/mthree_test && rm -f /tmp/mthree_test/test_converters.py && rm -f /tmp/mthree_test/test_columns.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_TEST_REQUIRES: pytest qiskit-aer
+          CIBW_TEST_REQUIRES: pytest qiskit-aer setuptools
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test
           CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test
           CIBW_TEST_COMMAND_MACOS:  pytest -p no:warnings /tmp/mthree_test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_SKIP: "cp36-* cp37-* pp* *musl*"
-          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp310-manylinux*"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-win_amd64 *-manylinux_i686 cp310-manylinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
           CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_ARCHS_MACOS: x86_64 universal2

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -33,7 +33,7 @@ from mthree.circuits import (
     balanced_cal_circuits,
 )
 from mthree.matrix import _reduced_cal_matrix, sdd_check
-from mthree.utils import counts_to_vector, vector_to_quasiprobs
+from mthree.utils import counts_to_vector, vector_to_quasiprobs, gmres
 from mthree.norms import ainv_onenorm_est_lu, ainv_onenorm_est_iter
 from mthree.matvec import M3MatVec
 from mthree.exceptions import M3Error
@@ -779,7 +779,7 @@ class M3Mitigation:
 
         P = spla.LinearOperator((M.num_elems, M.num_elems), precond_matvec)
         vec = counts_to_vector(M.sorted_counts)
-        out, error = spla.gmres(
+        out, error = gmres(
             L,
             vec,
             rtol=tol,

--- a/mthree/norms.py
+++ b/mthree/norms.py
@@ -15,7 +15,9 @@
 import numpy as np
 import scipy.linalg as la
 import scipy.sparse.linalg as spla
+
 from mthree.exceptions import M3Error
+from mthree.utils import gmres
 
 
 def ainv_onenorm_est_lu(A, LU=None):
@@ -134,14 +136,14 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
     v = (1.0/dims)*np.ones(dims, dtype=float)
 
     # Initial solve
-    v, error = spla.gmres(L, v, rtol=tol, atol=tol, maxiter=max_iter,
-                          M=P)
+    v, error = gmres(L, v, rtol=tol, atol=tol, maxiter=max_iter,
+                     M=P)
     if error:
         raise M3Error('Iterative solver error {}'.format(error))
     gamma = la.norm(v, 1)
     eta = np.sign(v)
-    x, error = spla.gmres(LT, eta, rtol=tol, atol=tol, maxiter=max_iter,
-                          M=P)
+    x, error = gmres(LT, eta, rtol=tol, atol=tol, maxiter=max_iter,
+                     M=P)
     if error:
         raise M3Error('Iterative solver error {}'.format(error))
     # loop over reasonable number of trials
@@ -151,8 +153,8 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
         idx = np.where(np.abs(x) == x_nrm)[0][0]
         v = np.zeros(dims, dtype=float)
         v[idx] = 1
-        v, error = spla.gmres(L, v, rtol=tol, atol=tol, maxiter=max_iter,
-                              M=P)
+        v, error = gmres(L, v, rtol=tol, atol=tol, maxiter=max_iter,
+                         M=P)
         if error:
             raise M3Error('Iterative solver error {}'.format(error))
         gamma_prime = gamma
@@ -162,8 +164,8 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
             break
 
         eta = np.sign(v)
-        x, error = spla.gmres(LT, eta, rtol=tol, atol=tol, maxiter=max_iter,
-                              M=P)
+        x, error = gmres(LT, eta, rtol=tol, atol=tol, maxiter=max_iter,
+                         M=P)
         if error:
             raise M3Error('Iterative solver error {}'.format(error))
         if la.norm(x, np.inf) == x[idx]:
@@ -174,8 +176,8 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
     x = np.arange(1, dims+1)
     x = (-1)**(x+1)*(1+(x-1)/(dims-1))
 
-    x, error = spla.gmres(L, x, rtol=tol, atol=tol, maxiter=max_iter,
-                          M=P)
+    x, error = gmres(L, x, rtol=tol, atol=tol, maxiter=max_iter,
+                     M=P)
     if error:
         raise M3Error('Iterative solver error {}'.format(error))
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from Cython.Build import cythonize
 
 MAJOR = 2
 MINOR = 6
-MICRO = 2
+MICRO = 3
 
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)


### PR DESCRIPTION
Scipy 1.11 added the `rtol` option to `scipy.sparse.linalg.gmres`, which is now the preferred form.  There are no prebuilt wheels for Scipy 1.11 for Python 3.8 on `pip` (and `mthree` lists its requirement as `scipy>=1.3`), so this adds in a dynamic switch to the `gmres` function to use the correct keyword argument based on the detect keyword argument.

This is what failed the 2.6.2 wheel builds - the test suite here uses Conda as its package manager, which provides a different set of built wheels to PyPI.