### PR TITLE
Use token username for wheels deployments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Publish to PyPi
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: nonhermitian
+          TWINE_USERNAME: __token__
         run: twine upload ./wheelhouse/*whl
   sdist-build:
     name: Build and Publish Release Artifacts


### PR DESCRIPTION
The username of the wheels deployment job had been left as `nonhermitian`, but it needs to be `__token__` to use the API token.