### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,10 +27,10 @@ jobs:
     - name: Install dependencies
       run: |
         conda config --set always_yes yes --set changeps1 no
-        pip install -U -r requirements.txt
+        pip install -U -r requirements.txt -c constraints.txt
     - name: Lint with pylint and pycodestyle
       run: |
-        pip install -U -r requirements-dev.txt
+        pip install -U -r requirements-dev.txt -c constraints.txt
         python setup.py build_ext --inplace
         pylint -rn mthree
         pycodestyle --max-line-length=100 mthree

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+astroid~=3.0.1  # Must be kept aligned to what pylint wants
+ipykernel==6.11.0

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -75,7 +75,7 @@ For example let us compare raw data verse the mitigated results in a simple case
     qc.cx(1, 0)
     qc.measure_all()
 
-    raw_counts = execute(qc, backend).result().get_counts()
+    raw_counts = backend.run(qc).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(4),
@@ -117,7 +117,7 @@ mitigate 5 circuits:
 
 .. jupyter-execute::
 
-    raw_counts = execute([qc]*5, backend).result().get_counts()
+    raw_counts = backend.run([qc]*5).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(4),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 qiskit-aer>=0.13
 pytest
 pylint~=3.0.2
-astroid~=3.0.1  # Must be kept aligned to what pylint wants
 pycodestyle
 Sphinx>=7.0,<=8
 qiskit_sphinx_theme~=1.12.0
@@ -10,6 +9,5 @@ pylatexenc
 jupyter-sphinx
 nbsphinx
 psutil
-ipykernel==6.11.0
 Jinja2<3.1
 quantum-styles

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 qiskit-aer>=0.13
 pytest
-pylint==2.16.2
+pylint~=3.0.2
+astroid~=3.0.1  # Must be kept aligned to what pylint wants
 pycodestyle
 Sphinx>=7.0,<=8
 qiskit_sphinx_theme~=1.12.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,6 @@ pylatexenc
 jupyter-sphinx
 nbsphinx
 psutil
-ipykernel<6
+ipykernel==6.11.0
 Jinja2<3.1
 quantum-styles

--- a/tutorials/10_basic_vqe.ipynb
+++ b/tutorials/10_basic_vqe.ipynb
@@ -301,7 +301,7 @@
    "source": [
     "def vqe_func(params, *args):\n",
     "    # Attach parameters to the transpiled circuit variables\n",
-    "    bound_circs = [circ.bind_parameters(params) for circ in trans_circs]\n",
+    "    bound_circs = [circ.assign_parameters(params) for circ in trans_circs]\n",
     "    # Submit the job and get the resultant counts back\n",
     "    counts = backend.run(bound_circs, shots=4096).result().get_counts()\n",
     "    # Apply mitigation to get quasi-probabilities\n",


### PR DESCRIPTION
CI was broken for four reasons:

1. `pylint` was pinned to version 2.16.2 which doesn't support Python 3.12 and 3.11 officially
2. Python 3.12 removed support for the `imp` library in favor of `importlib` and we were using a version of `ipykernal` that was importing the old library. The PR pins `ipykernal` to the first version supporting `importlib`. See this [issue](https://github.com/ipython/ipykernel/issues/560).
3. The ['QuantumCircuit' object has no method 'bind_parameters'](https://github.com/Qiskit-Extensions/mthree/actions/runs/8139415639/job/22242521172?pr=209) in qiskit 1.0 as we can see in [#791](https://github.com/Qiskit-Extensions/mthree/actions/runs/8139415639/job/22242521172#step:8:182) . This PR replaces the call to `bind_parameters` for `assign_parameters` as explained in the qiskit 1.0 [release notes](https://docs.quantum.ibm.com/api/qiskit/release-notes/1.0#circuits-upgrade-notes).
4. The `qiskit.execute` function is not available in Qiskit 1.0 anymore -> [Migration guide](https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-features#execute)