### PR TITLE
Fix NumPy V2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython>=0.29", "oldest-supported-numpy"]
+requires = ["setuptools", "wheel", "cython>=3.0.10", "numpy>=2.0,<3"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.17,<2
+numpy>=1.17
 scipy>=1.3
 cython>=3.0.10
 qiskit>=1.0

--- a/setup.py
+++ b/setup.py
@@ -86,9 +86,7 @@ for idx, ext in enumerate(CYTHON_EXTS):
                                include_dirs=INCLUDE_DIRS,
                                extra_compile_args=COMPILER_FLAGS+OPTIONAL_FLAGS,
                                extra_link_args=LINK_FLAGS+OPTIONAL_ARGS,
-                               language='c++',
-                               define_macros=[("NPY_NO_DEPRECATED_API", 
-                                               "NPY_1_7_API_VERSION")])
+                               language='c++')
     EXT_MODULES.append(mod)
 
 


### PR DESCRIPTION
We were using the oldest-supported-numpy feature in the build system which prevented using NumPy 2.0 and is no longer supported.  This moves to the suggested alternative.