### PR TITLE
Add back tests for faulty qubits

### DIFF
--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -26,13 +26,13 @@ BACKEND = FakeKolkataV2()
 properties = BACKEND.properties().to_dict()
 for faulty_qubit in faulty:
     properties["qubits"][faulty_qubit].append({"date": datetime.now(),
-                                               "name": "operational", 
+                                               "name": "operational",
                                                "unit": "", "value": 0})
 
 FAULTY_BACKEND = IBMBackend(configuration=BACKEND.configuration(),
                             service=None, api_client=None, instance=None)
 
-FAULTY_BACKEND.properties = lambda: BackendProperties.from_dict(properties)  
+FAULTY_BACKEND.properties = lambda: BackendProperties.from_dict(properties)
 
 
 def test_inoperable_qubits1():

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -11,8 +11,8 @@
 # that they have been altered from the originals.
 
 """Test inoperable qubits"""
-import pytest
 from datetime import datetime
+import pytest
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
 from qiskit_ibm_runtime.models import BackendProperties
 from qiskit_ibm_runtime.fake_provider import FakeKolkataV2

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -21,6 +21,10 @@ import mthree
 
 faulty = [1, 3, 5, 7]
 
+class Service:
+    def __init__(self) -> None:
+        self._channel_strategy = 'test'
+
 
 BACKEND = FakeKolkataV2()
 properties = BACKEND.properties().to_dict()
@@ -30,7 +34,7 @@ for faulty_qubit in faulty:
                                                "unit": "", "value": 0})
 
 FAULTY_BACKEND = IBMBackend(configuration=BACKEND.configuration(),
-                            service={'_channel_strategy': 'test'}, 
+                            service=Service(), 
                             api_client=None, instance=None)
 
 FAULTY_BACKEND.properties = lambda: BackendProperties.from_dict(properties)

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -22,6 +22,7 @@ import mthree
 faulty = [1, 3, 5, 7]
 
 class Service:
+    """Some class docstring"""
     def __init__(self) -> None:
         self._channel_strategy = 'test'
 
@@ -34,7 +35,7 @@ for faulty_qubit in faulty:
                                                "unit": "", "value": 0})
 
 FAULTY_BACKEND = IBMBackend(configuration=BACKEND.configuration(),
-                            service=Service(), 
+                            service=Service(),
                             api_client=None, instance=None)
 
 FAULTY_BACKEND.properties = lambda: BackendProperties.from_dict(properties)

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -13,19 +13,12 @@
 """Test inoperable qubits"""
 from datetime import datetime
 import pytest
-from qiskit_ibm_runtime.ibm_backend import IBMBackend
 from qiskit_ibm_runtime.models import BackendProperties
 from qiskit_ibm_runtime.fake_provider import FakeKolkataV2
 import mthree
 
 
 faulty = [1, 3, 5, 7]
-
-
-class Service:
-    """Some class docstring"""
-    def __init__(self) -> None:
-        self._channel_strategy = 'test'
 
 
 BACKEND = FakeKolkataV2()
@@ -35,16 +28,12 @@ for faulty_qubit in faulty:
                                                "name": "operational",
                                                "unit": "", "value": 0})
 
-FAULTY_BACKEND = IBMBackend(configuration=BACKEND.configuration(),
-                            service=Service(),
-                            api_client=None, instance=None)
-
-FAULTY_BACKEND.properties = lambda: BackendProperties.from_dict(properties)
+BACKEND.properties = lambda: BackendProperties.from_dict(properties)
 
 
 def test_inoperable_qubits1():
     """Test that inoperable qubits are ignored"""
-    mit = mthree.M3Mitigation(FAULTY_BACKEND)
+    mit = mthree.M3Mitigation(BACKEND)
     mit.cals_from_system()
     for qubit in faulty:
         assert mit.single_qubit_cals[qubit] is None
@@ -52,6 +41,6 @@ def test_inoperable_qubits1():
 
 def test_inoperable_qubits2():
     """Test that explicitly using inoperable qubits raises error"""
-    mit = mthree.M3Mitigation(FAULTY_BACKEND)
+    mit = mthree.M3Mitigation(BACKEND)
     with pytest.raises(mthree.exceptions.M3Error):
         mit.cals_from_system([0, 3])

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -30,7 +30,8 @@ for faulty_qubit in faulty:
                                                "unit": "", "value": 0})
 
 FAULTY_BACKEND = IBMBackend(configuration=BACKEND.configuration(),
-                            service=None, api_client=None, instance=None)
+                            service={'_channel_strategy': 'test'}, 
+                            api_client=None, instance=None)
 
 FAULTY_BACKEND.properties = lambda: BackendProperties.from_dict(properties)
 

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -21,6 +21,7 @@ import mthree
 
 faulty = [1, 3, 5, 7]
 
+
 class Service:
     """Some class docstring"""
     def __init__(self) -> None:


### PR DESCRIPTION
Adds back tests for faulty qubits following this https://github.com/Qiskit/qiskit-ibm-runtime/blob/819808ead0b0f580b9b821698b93a43b25044c7e/test/utils.py#L247-L305 as a guide