### PR TITLE
Restrict number of bionomial terms to max dim(A)

### DIFF
--- a/mthree/src/col_renorm.h
+++ b/mthree/src/col_renorm.h
@@ -44,7 +44,7 @@ void compute_col_norms(float * col_norms,
         MAX_DIST = true;
       }
       else{
-        num_terms = hamming_terms(num_bits, distance); 
+        num_terms = (int)hamming_terms(num_bits, distance, num_elems); 
       }
 
       #pragma omp parallel for

--- a/mthree/src/distance.h
+++ b/mthree/src/distance.h
@@ -46,7 +46,7 @@ static inline bool within_distance(unsigned int row,
   }
 
 
-static inline unsigned int binomial_coeff(unsigned int n, unsigned int k)
+static inline long long binomial_coeff(unsigned int n, unsigned int k)
   {
     if (k > n)
       {
@@ -71,12 +71,27 @@ static inline unsigned int binomial_coeff(unsigned int n, unsigned int k)
   }
 
 
-unsigned int hamming_terms(unsigned int num_bits, unsigned int distance)
+unsigned int hamming_terms(unsigned int num_bits, unsigned int distance, unsigned int num_elems)
+  /**
+   * @brief Computes number of Hamming terms of a given distance, up to the total number of elements
+   *
+   * @param num_bits Number of length of the bit-strings
+   * @param distance Distance to consider
+   * @param num_elems Number of elements (dimension) of reduced A-matrix
+   *
+   * @return Number of elements within distance or num_elems at most 
+   */
 {
-  unsigned int kk, out = 0;
+  unsigned int kk;
+  unsigned int out = 0;
   for (kk=0; kk < (distance+1); ++kk)
     {
       out += binomial_coeff(num_bits, kk);
+      if (out >= num_elems)
+      {
+        out = num_elems;
+        break;
+      }
     }
   return out;
 }


### PR DESCRIPTION
The number of binomial terms grows quickly with distance when the number of bitstrings is large.  We use this value as a cutoff for doing column renormalization.  At worst this number is equal to the dimensionality of the reduced A-matrix, and thus we do not need to compute all terms.

This PR restricts the binomial computation to <= dim(A)