### PR TITLE
Add back macros for deprecated numpy api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.17
+numpy>=1.23
 scipy>=1.3
 cython>=3.0.10
 qiskit>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.23
-scipy>=1.3
+scipy>=1.11.1
 cython>=3.0.10
 qiskit>=1.0
 qiskit_ibm_runtime>=0.22

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ if (sys.platform == 'win32' and os.environ.get('MSYSTEM', None) is None):
     COMPILER_FLAGS = ['/O3']
 # Everything else
 else:
-    COMPILER_FLAGS = ['-O3', '-std=c++17']
+    COMPILER_FLAGS = ['-O3', '-std=c++17', '-DNPY_NO_DEPRECATED_API=NPY_1_23_API_VERSION']
 
 EXT_MODULES = []
 # Add Cython Extensions
@@ -86,9 +86,7 @@ for idx, ext in enumerate(CYTHON_EXTS):
                                include_dirs=INCLUDE_DIRS,
                                extra_compile_args=COMPILER_FLAGS+OPTIONAL_FLAGS,
                                extra_link_args=LINK_FLAGS+OPTIONAL_ARGS,
-                               language='c++',
-                               define_macros=[("NPY_NO_DEPRECATED_API", 
-                                               "NPY_1_7_API_VERSION")])
+                               language='c++')
     EXT_MODULES.append(mod)
 
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,9 @@ for idx, ext in enumerate(CYTHON_EXTS):
                                include_dirs=INCLUDE_DIRS,
                                extra_compile_args=COMPILER_FLAGS+OPTIONAL_FLAGS,
                                extra_link_args=LINK_FLAGS+OPTIONAL_ARGS,
-                               language='c++')
+                               language='c++',
+                               define_macros=[("NPY_NO_DEPRECATED_API", 
+                                               "NPY_1_7_API_VERSION")])
     EXT_MODULES.append(mod)
 
 


### PR DESCRIPTION
I naively assumed the old NumPy API warnings would be gone in NumPy 2.0, but I was wrong. This adds the macros back to stop the warning messages.