### PR TITLE
allow for setting march via env var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ if WITH_OMP or os.getenv("MTHREE_OPENMP", False):
         OPTIONAL_FLAGS = ['-fopenmp']
     OPTIONAL_ARGS = OPTIONAL_FLAGS
 
+if os.getenv("MTHREE_ARCH", False):
+    OPTIONAL_FLAGS.append('-march='+os.getenv("MTHREE_ARCH"))
+
 INCLUDE_DIRS = [np.get_include()]
 # Extra link args
 LINK_FLAGS = []


### PR DESCRIPTION
A generic installation vectorizes only up to 128bits.  Setting `-march` to the target platform can yield vectortization up to 512bits, if supported.  This allows for setting that via an env var.  We should probably have a config file that allows for setting arbitrary compiler flags, but this is good enough for now to enable benchmarking