### PR TITLE
Reduce iterative tolerance to 1e-3

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -553,7 +553,7 @@ class M3Mitigation:
         distance=None,
         method="auto",
         max_iter=25,
-        tol=1e-5,
+        tol=1e-3,
         return_mitigation_overhead=False,
         details=False,
     ):
@@ -565,7 +565,7 @@ class M3Mitigation:
             distance (int): Distance to correct for. Default=num_bits
             method (str): Solution method: 'auto', 'direct' or 'iterative'.
             max_iter (int): Max. number of iterations, Default=25.
-            tol (float): Convergence tolerance of iterative method, Default=1e-5.
+            tol (float): Convergence tolerance of iterative method, Default=1e-3.
             return_mitigation_overhead (bool): Returns the mitigation overhead, default=False.
             details (bool): Return extra info, default=False.
 


### PR DESCRIPTION
The default iterative tolerance is 1e-5, which is too low for application here.  This increases the atol in the iterative solver to 1e-3