### PR TITLE
Set default distance to min(num_bits, 3)

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -448,7 +448,7 @@ class M3Mitigation:
         distance=None,
         method="auto",
         max_iter=25,
-        tol=1e-5,
+        tol=1e-3,
         return_mitigation_overhead=False,
         details=False,
     ):
@@ -460,7 +460,7 @@ class M3Mitigation:
             distance (int): Distance to correct for. Default=num_bits
             method (str): Solution method: 'auto', 'direct' or 'iterative'.
             max_iter (int): Max. number of iterations, Default=25.
-            tol (float): Convergence tolerance of iterative method, Default=1e-5.
+            tol (float): Convergence tolerance of iterative method, Default=1e-3.
             return_mitigation_overhead (bool): Returns the mitigation overhead, default=False.
             details (bool): Return extra info, default=False.
 
@@ -579,10 +579,12 @@ class M3Mitigation:
         counts = dict(counts)
         shots = sum(counts.values())
 
-        # If distance is None, then assume max distance.
+        # If distance is None, then assume min(num_bits, 3).
         num_bits = len(qubits)
         num_elems = len(counts)
         if distance is None:
+            distance = min(num_bits,3)
+        elif distance == -1: # shortcut for setting max distance
             distance = num_bits
 
         # check if len of bitstrings does not equal number of qubits passed.

--- a/mthree/test/test_full.py
+++ b/mthree/test/test_full.py
@@ -26,7 +26,7 @@ def test_full_problem():
     qubits = [1, 4, 7, 10, 12, 2, 3, 5]
     mit = M3Mitigation(None)
     mit.cals_from_matrices(CALS)
-    mit_counts = mit.apply_correction(COUNTS, qubits, tol=1e-6, method="iterative")
+    mit_counts = mit.apply_correction(COUNTS, qubits, distance=-1, tol=1e-6, method="iterative")
 
     # Compute using LU solver
     sorted_counts = dict(

--- a/mthree/test/test_methods.py
+++ b/mthree/test/test_methods.py
@@ -35,12 +35,12 @@ def test_methods_equality():
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
 
-    iter_q = mit.apply_correction(raw_counts, range(5), method="iterative")
-    direct_q = mit.apply_correction(raw_counts, range(5), method="direct")
+    iter_q = mit.apply_correction(raw_counts, range(5), distance=-1, method="iterative")
+    direct_q = mit.apply_correction(raw_counts, range(5), distance=-1, method="direct")
 
     for key, val in direct_q.items():
         assert key in iter_q.keys()
-        assert np.abs(val - iter_q[key]) < 1e-5
+        assert np.abs(val - iter_q[key]) < 1e-4
 
 
 def test_set_iterative():


### PR DESCRIPTION
With low error rates, the max Hamming distance can be restricted to 3 at most.  This makes that change.

Setting the max distance `distance=num_bits` can be set easily via `distance=-1`.