### PR TITLE
Cleanup array handling for iterative solver

### DIFF
--- a/mthree/converters.pxd
+++ b/mthree/converters.pxd
@@ -13,11 +13,20 @@
 from libcpp.map cimport map
 from libcpp.string cimport string
 
+
 cdef void counts_to_internal(map[string, float] * counts,
                              unsigned char * vec,
                              float * probs,
                              unsigned int num_bits,
                              float shots)
 
+
 cdef void internal_to_probs(map[string, float] * counts,
                             float * probs)
+
+
+cdef void _core_counts_to_bp(map[string, float] * counts_map,
+                             unsigned int num_bits,
+                             float shots,
+                             unsigned char * bitstrings,
+                             float * probs)

--- a/mthree/converters.pyx
+++ b/mthree/converters.pyx
@@ -11,6 +11,8 @@
 # that they have been altered from the originals.
 # cython: c_string_type=unicode, c_string_encoding=UTF-8
 cimport cython
+import numpy as np
+cimport numpy as np
 from libcpp.map cimport map
 from libcpp.string cimport string
 from cython.operator cimport dereference, postincrement
@@ -64,5 +66,51 @@ cdef void internal_to_probs(map[string, float] * counts_map,
 
     while it != end:
         dereference(it).second = probs[idx]
+        idx += 1
+        postincrement(it)
+
+
+def counts_to_bitstrings_and_probs(object counts):
+    """Convert counts to NumPy arrays of bitstrings and probabilities
+
+    Parameters:
+        counts (object): Dict or Counts object of counts data
+
+    Returns:
+        ndarray: Array of unsigned char bitstrings
+        ndarray: Array of float probabilities
+    """
+    cdef float shots = sum(counts.values())
+    cdef map[string, float] counts_map = counts
+    cdef unsigned int num_elems = counts_map.size()
+    cdef unsigned int num_bits = len(next(iter(counts)))
+
+    cdef unsigned char[::1] bitstrings = np.empty(num_bits*num_elems, dtype=np.uint8)
+    cdef float[::1] probs = np.empty(num_elems, dtype=np.float32)
+
+    _core_counts_to_bp(&counts_map, num_bits, shots,
+                       &bitstrings[0], &probs[0])
+
+    return np.asarray(bitstrings), np.asarray(probs)
+
+
+@cython.cdivision(True)
+cdef void _core_counts_to_bp(map[string, float] * counts_map,
+                             unsigned int num_bits,
+                             float shots,
+                             unsigned char * bitstrings,
+                             float * probs):
+
+    cdef unsigned int idx, letter, start
+    cdef map[string, float].iterator end = counts_map.end()
+    cdef map[string, float].iterator it = counts_map.begin()
+    cdef string temp
+    idx = 0
+    while it != end:
+        start = num_bits*idx
+        probs[idx] = dereference(it).second / shots
+        temp = dereference(it).first
+        for letter in range(num_bits):
+            bitstrings[start+letter] = <unsigned char>temp[letter]-48
         idx += 1
         postincrement(it)

--- a/mthree/iterative.py
+++ b/mthree/iterative.py
@@ -77,7 +77,7 @@ def iterative_solver(
         (M.num_elems, M.num_elems), precond_matvec, dtype=np.float32
     )
     st = time.perf_counter()
-    vec = counts_to_vector(M.sorted_counts)
+    vec = np.asarray(M.probs, np.float32)
     fin = time.perf_counter()
     logger.info(f"Counts to vector time: {fin-st}")
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -583,8 +583,8 @@ class M3Mitigation:
         num_bits = len(qubits)
         num_elems = len(counts)
         if distance is None:
-            distance = min(num_bits,3)
-        elif distance == -1: # shortcut for setting max distance
+            distance = min(num_bits, 3)
+        elif distance == -1:  # shortcut for setting max distance
             distance = num_bits
 
         # check if len of bitstrings does not equal number of qubits passed.

--- a/mthree/test/test_full.py
+++ b/mthree/test/test_full.py
@@ -26,7 +26,9 @@ def test_full_problem():
     qubits = [1, 4, 7, 10, 12, 2, 3, 5]
     mit = M3Mitigation(None)
     mit.cals_from_matrices(CALS)
-    mit_counts = mit.apply_correction(COUNTS, qubits, distance=-1, tol=1e-6, method="iterative")
+    mit_counts = mit.apply_correction(
+        COUNTS, qubits, distance=-1, tol=1e-6, method="iterative"
+    )
 
     # Compute using LU solver
     sorted_counts = dict(


### PR DESCRIPTION
Cleans up the memory handling of the iterative method add removes calls to `malloc` and `free`