### PR TITLE
Fix type of binomial coeff

### DIFF
--- a/mthree/src/distance.h
+++ b/mthree/src/distance.h
@@ -47,7 +47,7 @@ static inline bool within_distance(unsigned int row,
   }
 
 
-static inline long long binomial_coeff(unsigned int n, unsigned int k)
+static inline unsigned int binomial_coeff(unsigned int n, unsigned int k)
   {
     if (k > n)
       {


### PR DESCRIPTION
The type was cast to `long long` but since we can cap the calculation at the total number of bitstrings we can just use an `unsigned int`.